### PR TITLE
Polish premium homepage styling (hero, trust badges, product cards)

### DIFF
--- a/assets/custom-enhancements.css
+++ b/assets/custom-enhancements.css
@@ -244,3 +244,98 @@ img {
 .lazy-image.loaded {
   opacity: 1;
 }
+
+/* ========================================
+   PREMIUM THEME POLISH (MAIN CONTENT ONLY)
+   ======================================== */
+
+main.content-for-layout {
+  background: linear-gradient(180deg, #f6f4ef 0%, #fbfaf7 45%, #f1f2ee 100%);
+  color: #1c1f1a;
+}
+
+main.content-for-layout :is(h1, h2, h3, h4, .h1, .h2, .h3, .h4) {
+  letter-spacing: -0.02em;
+}
+
+main.content-for-layout .hero__content-wrapper {
+  max-width: 540px;
+  padding: 28px 32px;
+  border-radius: 22px;
+  background: rgba(18, 23, 18, 0.52);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 24px 50px rgba(10, 14, 9, 0.32);
+  backdrop-filter: blur(14px);
+}
+
+main.content-for-layout .hero__content-wrapper :is(p, .rte) {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+main.content-for-layout .hero__content-wrapper :is(h1, h2, h3, .h1, .h2, .h3) {
+  color: #fdf8ec;
+  text-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+main.content-for-layout .section-resource-list {
+  border-radius: 26px;
+  border: 1px solid rgba(26, 34, 20, 0.08);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 22px 44px rgba(16, 24, 12, 0.1);
+  overflow: hidden;
+}
+
+main.content-for-layout .section-resource-list__header {
+  padding-bottom: 14px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+main.content-for-layout .product-card {
+  border-radius: 18px;
+  border: 1px solid rgba(22, 28, 18, 0.08);
+  background: #ffffff;
+  box-shadow: 0 14px 34px rgba(12, 18, 9, 0.08);
+  overflow: hidden;
+}
+
+main.content-for-layout .product-card__content {
+  padding: 16px 18px 20px;
+}
+
+main.content-for-layout .product-card :is(h4, .h4) {
+  font-weight: 600;
+}
+
+main.content-for-layout .button {
+  border-radius: 999px;
+  letter-spacing: 0.02em;
+}
+
+main.content-for-layout .button--primary {
+  background: linear-gradient(135deg, #1f3a1d 0%, #2b4f28 100%);
+  border: none;
+  box-shadow: 0 12px 28px rgba(16, 26, 12, 0.32);
+}
+
+main.content-for-layout .button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(16, 26, 12, 0.38);
+}
+
+main.content-for-layout .button--secondary,
+main.content-for-layout .button-secondary {
+  border: 1px solid rgba(28, 36, 22, 0.2);
+  background: rgba(255, 255, 255, 0.92);
+  color: #1f2a1b;
+}
+
+@media (max-width: 768px) {
+  main.content-for-layout .hero__content-wrapper {
+    padding: 22px;
+    border-radius: 16px;
+  }
+
+  main.content-for-layout .section-resource-list {
+    border-radius: 18px;
+  }
+}

--- a/assets/custom-outdoor-homepage.css
+++ b/assets/custom-outdoor-homepage.css
@@ -6,19 +6,19 @@
 .outdoor-hero-enhancements {
   position: relative;
   z-index: 10;
-  margin-top: -60px;
-  padding: 0 20px;
+  margin-top: -32px;
+  padding: 0 24px 24px;
 }
 
 /* ============================================
    COUNTDOWN TIMER
    ============================================ */
 .outdoor-hero-countdown {
-  background: linear-gradient(135deg, #ff6b6b 0%, #ee5a6f 100%);
-  border-radius: 12px;
+  background: linear-gradient(135deg, #1b2b17 0%, #284325 100%);
+  border-radius: 18px;
   padding: 16px 24px;
   margin-bottom: 24px;
-  box-shadow: 0 8px 24px rgba(255, 107, 107, 0.3);
+  box-shadow: 0 16px 32px rgba(13, 20, 10, 0.3);
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
@@ -33,19 +33,20 @@
 }
 
 .outdoor-hero-countdown__label {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
-  color: #ffffff;
-  letter-spacing: 0.3px;
+  color: rgba(255, 255, 255, 0.92);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
 }
 
 .outdoor-hero-countdown__timer {
   display: flex;
   align-items: center;
   gap: 6px;
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.14);
   padding: 8px 16px;
-  border-radius: 8px;
+  border-radius: 10px;
   backdrop-filter: blur(10px);
 }
 
@@ -59,10 +60,10 @@
   font-size: 24px;
   font-weight: 700;
   font-family: 'Courier New', monospace;
-  color: #ffffff;
+  color: #f2e6b8;
   min-width: 28px;
   text-align: center;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 
 .outdoor-hero-countdown__unit-label {
@@ -82,11 +83,12 @@
    TRUST BADGES
    ============================================ */
 .outdoor-hero-trust-badges {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 16px;
-  padding: 24px;
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 24px;
+  padding: 32px;
   margin-bottom: 24px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 28px 56px rgba(12, 18, 9, 0.12);
+  border: 1px solid rgba(45, 80, 22, 0.1);
   backdrop-filter: blur(10px);
   max-width: 1000px;
   margin-left: auto;
@@ -103,15 +105,17 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px;
-  background: rgba(45, 80, 22, 0.03);
-  border-radius: 8px;
+  padding: 14px 16px;
+  background: #ffffff;
+  border-radius: 14px;
+  border: 1px solid rgba(45, 80, 22, 0.08);
   transition: all 0.3s ease;
 }
 
 .outdoor-hero-trust-badge:hover {
-  background: rgba(45, 80, 22, 0.06);
+  background: #ffffff;
   transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(35, 60, 18, 0.12);
 }
 
 .outdoor-hero-trust-badge__icon {
@@ -123,8 +127,8 @@
 
 .outdoor-hero-trust-badge__text {
   font-size: 14px;
-  font-weight: 500;
-  color: #333;
+  font-weight: 600;
+  color: #1f2a1b;
   line-height: 1.4;
 }
 
@@ -132,11 +136,11 @@
    STATS
    ============================================ */
 .outdoor-hero-stats {
-  background: linear-gradient(135deg, #2d5016 0%, #3a6b1e 100%);
-  border-radius: 16px;
-  padding: 32px 24px;
+  background: linear-gradient(135deg, #1a2a15 0%, #254322 100%);
+  border-radius: 24px;
+  padding: 40px 32px;
   margin-bottom: 24px;
-  box-shadow: 0 8px 24px rgba(45, 80, 22, 0.3);
+  box-shadow: 0 26px 54px rgba(12, 20, 10, 0.35);
   max-width: 1000px;
   margin-left: auto;
   margin-right: auto;
@@ -150,25 +154,25 @@
 
 .outdoor-hero-stat {
   text-align: center;
-  padding: 16px;
+  padding: 18px;
   background: rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
   transition: all 0.3s ease;
 }
 
 .outdoor-hero-stat:hover {
-  background: rgba(255, 255, 255, 0.15);
-  transform: scale(1.05);
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-3px);
 }
 
 .outdoor-hero-stat__value {
   font-size: 32px;
   font-weight: 700;
-  color: var(--outdoor-gold, #d4af37);
+  color: #f2e6b8;
   line-height: 1.2;
   margin-bottom: 8px;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
 }
 
 .outdoor-hero-stat__label {
@@ -185,8 +189,8 @@
    ============================================ */
 @media screen and (max-width: 768px) {
   .outdoor-hero-enhancements {
-    margin-top: -40px;
-    padding: 0 16px;
+    margin-top: -24px;
+    padding: 0 16px 16px;
   }
   
   .outdoor-hero-countdown {


### PR DESCRIPTION
### Motivation
- Make the homepage feel more premium and cohesive by refining hero visuals, trust badges, stat cards and featured collection presentation.
- Soften and rebalance spacing, radii, shadows and color accents for a higher-end aesthetic.
- Improve mobile spacing and subtle hover/transform behaviors for a more polished interactive feel.

### Description
- Updated `assets/custom-outdoor-homepage.css` to adjust hero spacing, countdown background, trust-badge layout, stat cards, colors, radii, shadows and responsive breakpoints.
- Updated `assets/custom-enhancements.css` to scope premium polish under `main.content-for-layout` including the hero content wrapper, product-card sizing/padding, button gradients and hover shadows.
- Tweaked typography contrast and text-shadows for hero headings and countdown values, and reduced transform/hover intensity across badges and stats.
- Adjusted several mobile rules to improve padding and top-margin in narrow viewports.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b6527e38c8329b429d41d3436e6e0)